### PR TITLE
Load config from package.json as well as elk.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "tap --no-coverage",
-    "test:snapshot": "TAP_SNAPSHOT=1 tap --no-esm test/*.js --no-coverage",
+    "test:snapshot": "TAP_SNAPSHOT=1 tap test/*.js --no-coverage",
     "lint": "eslint . --ext=js",
     "lint:fix": "eslint . --fix --ext=js"
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "tap": "15.0.5"
   },
   "dependencies": {
+    "@eik/common": "^3.0.0",
     "esbuild-plugin-import-map": "2.1.0",
     "node-fetch": "2.6.6"
   }

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -64,3 +64,23 @@ export {
 };
 
 `
+
+exports[`test/plugin.js TAP plugin() - import maps via package.json, URLs and direct definitions > import maps from eik.json, urls and direct definition 1`] = `
+// fixtures/modules/file/main.js
+import {html} from "https://cdn.eik.dev/lit-html/v2";
+import {css} from "https://cdn.eik.dev/lit-html/v1";
+import {LitElement} from "https://cdn.eik.dev/lit-element/v2";
+var Inner = class extends LitElement {
+  static get styles() {
+    return [css\`:host { color: red; }\`];
+  }
+  render(world) {
+    return html\`<p>Hello \${world}!</p>\`;
+  }
+};
+var main_default = Inner;
+export {
+  main_default as default
+};
+
+`

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -43,6 +43,14 @@ tap.test('plugin() - import map fetched from a URL', async (t) => {
     });
     const address = await server.listen();
 
+    await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
+        name: 'test',
+        server: 'https://localhost',
+        version: '1.0.0',
+        files: './dist',
+        'import-map': `${address}/one`,
+    }));
+
     await plugin.load({
         maps: [{
             imports: {
@@ -86,9 +94,9 @@ tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
         name: 'test',
+        server: 'https://localhost',
         version: '1.0.0',
-        js: '',
-        css: '',
+        files: './dist',
         'import-map': `${address}/one`,
     }));
 
@@ -135,8 +143,8 @@ tap.test('plugin() - import maps via eik.json, URLs and direct definitions', asy
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
         name: 'test',
         version: '1.0.0',
-        js: '',
-        css: '',
+        server: 'https://localhost',
+        files: './dist',
         'import-map': `${address}/one`,
     }));
 


### PR DESCRIPTION
This PR adds the same support for loading from package.json as can be found in the Eik rollup plugin here: https://github.com/eik-lib/rollup-plugin/blob/master/src/plugin.js

The Eik common module is used to load.

Additional comments/explanations inline on the PR