### PR TITLE
fix: Replace node-fetch with undici

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: npm install
         run: |
           npm install
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: npm install
         run: |
           npm install

--- a/package.json
+++ b/package.json
@@ -36,22 +36,18 @@
   "homepage": "https://github.com/eik-lib/esbuild-plugin#readme",
   "devDependencies": {
     "@semantic-release/changelog": "6.0.1",
-    "@semantic-release/commit-analyzer": "9.0.2",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "8.0.2",
-    "@semantic-release/npm": "9.0.0",
-    "@semantic-release/release-notes-generator": "10.0.3",
-    "esbuild": "0.9.0",
-    "eslint": "7.32.0",
-    "eslint-config-airbnb-base": "14.2.1",
-    "eslint-plugin-import": "2.24.0",
-    "fastify": "3.13.0",
+    "esbuild": "0.14.13",
+    "eslint": "8.7.0",
+    "eslint-config-airbnb-base": "15.0.0",
+    "eslint-plugin-import": "2.25.4",
+    "fastify": "3.27.0",
     "semantic-release": "19.0.2",
-    "tap": "15.0.5"
+    "tap": "15.1.6"
   },
   "dependencies": {
-    "@eik/common": "^3.0.0",
+    "@eik/common": "3.0.0",
     "esbuild-plugin-import-map": "2.1.0",
-    "node-fetch": "2.6.7"
+    "undici": "4.12.2"
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,28 +1,33 @@
 /* eslint-disable no-restricted-syntax */
 
 import * as importMapPlugin from 'esbuild-plugin-import-map';
-import fetch from 'node-fetch';
 import { helpers } from '@eik/common';
+import { request } from 'undici';
 
-async function fetchImportMaps(urls = []) {
+const fetchImportMaps = async (urls = []) => {
     try {
-        const maps = urls.map((map) => fetch(map).then((result) => {
-            if (result.status === 404) {
+        const maps = urls.map(async (map) => {
+            const {
+                statusCode,
+                body,
+            } = await request(map, { maxRedirections: 2 });
+
+            if (statusCode === 404) {
                 throw new Error('Import map could not be found on server');
-            } else if (result.status >= 400 && result.status < 500) {
+            } else if (statusCode >= 400 && statusCode < 500) {
                 throw new Error('Server rejected client request');
-            } else if (result.status >= 500) {
+            } else if (statusCode >= 500) {
                 throw new Error('Server error');
             }
-            return result.json();
-        }));
+            return body.json();
+        });
         return await Promise.all(maps);
     } catch (err) {
         throw new Error(
             `Unable to load import map file from server: ${err.message}`,
         );
     }
-}
+};
 
 export async function load({
     path = process.cwd(),

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -7,9 +7,9 @@
 'use strict'
 exports[`test/plugin.js TAP plugin() - import map fetched from a URL > import maps from urls 1`] = `
 // fixtures/modules/file/main.js
-import {html} from "https://cdn.eik.dev/lit-html/v2";
-import {css} from "https://cdn.eik.dev/lit-html/v1";
-import {LitElement} from "https://cdn.eik.dev/lit-element/v2";
+import { html } from "https://cdn.eik.dev/lit-html/v2";
+import { css } from "https://cdn.eik.dev/lit-html/v1";
+import { LitElement } from "https://cdn.eik.dev/lit-element/v2";
 var Inner = class extends LitElement {
   static get styles() {
     return [css\`:host { color: red; }\`];
@@ -18,18 +18,17 @@ var Inner = class extends LitElement {
     return html\`<p>Hello \${world}!</p>\`;
   }
 };
-var main_default = Inner;
 export {
-  main_default as default
+  Inner as default
 };
 
 `
 
 exports[`test/plugin.js TAP plugin() - import map fetched from a URL via eik.json > eik.json import-map string 1`] = `
 // fixtures/modules/file/main.js
-import {html} from "https://cdn.eik.dev/lit-html/v2";
-import {css} from "https://cdn.eik.dev/lit-html/v1";
-import {LitElement} from "https://cdn.eik.dev/lit-element/v2";
+import { html } from "https://cdn.eik.dev/lit-html/v2";
+import { css } from "https://cdn.eik.dev/lit-html/v1";
+import { LitElement } from "https://cdn.eik.dev/lit-element/v2";
 var Inner = class extends LitElement {
   static get styles() {
     return [css\`:host { color: red; }\`];
@@ -38,18 +37,17 @@ var Inner = class extends LitElement {
     return html\`<p>Hello \${world}!</p>\`;
   }
 };
-var main_default = Inner;
 export {
-  main_default as default
+  Inner as default
 };
 
 `
 
 exports[`test/plugin.js TAP plugin() - import maps via eik.json, URLs and direct definitions > import maps from eik.json, urls and direct definition 1`] = `
 // fixtures/modules/file/main.js
-import {html} from "https://cdn.eik.dev/lit-html/v2";
-import {css} from "https://cdn.eik.dev/lit-html/v1";
-import {LitElement} from "https://cdn.eik.dev/lit-element/v2";
+import { html } from "https://cdn.eik.dev/lit-html/v2";
+import { css } from "https://cdn.eik.dev/lit-html/v1";
+import { LitElement } from "https://cdn.eik.dev/lit-element/v2";
 var Inner = class extends LitElement {
   static get styles() {
     return [css\`:host { color: red; }\`];
@@ -58,18 +56,17 @@ var Inner = class extends LitElement {
     return html\`<p>Hello \${world}!</p>\`;
   }
 };
-var main_default = Inner;
 export {
-  main_default as default
+  Inner as default
 };
 
 `
 
 exports[`test/plugin.js TAP plugin() - import maps via package.json, URLs and direct definitions > import maps from eik.json, urls and direct definition 1`] = `
 // fixtures/modules/file/main.js
-import {html} from "https://cdn.eik.dev/lit-html/v2";
-import {css} from "https://cdn.eik.dev/lit-html/v1";
-import {LitElement} from "https://cdn.eik.dev/lit-element/v2";
+import { html } from "https://cdn.eik.dev/lit-html/v2";
+import { css } from "https://cdn.eik.dev/lit-html/v1";
+import { LitElement } from "https://cdn.eik.dev/lit-element/v2";
 var Inner = class extends LitElement {
   static get styles() {
     return [css\`:host { color: red; }\`];
@@ -78,9 +75,8 @@ var Inner = class extends LitElement {
     return html\`<p>Hello \${world}!</p>\`;
   }
 };
-var main_default = Inner;
 export {
-  main_default as default
+  Inner as default
 };
 
 `

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -26,22 +26,23 @@ const bufferToString = (buff) => {
 };
 
 tap.test('plugin() - import map fetched from a URL', async (t) => {
-    const server = fastify();
-    server.get('/one', (request, reply) => {
+    const app = fastify();
+    app.server.keepAliveTimeout = 20;
+    app.get('/one', (request, reply) => {
         reply.send({
             imports: {
                 'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             },
         });
     });
-    server.get('/two', (request, reply) => {
+    app.get('/two', (request, reply) => {
         reply.send({
             imports: {
                 'lit-html': 'https://cdn.eik.dev/lit-html/v1',
             },
         });
     });
-    const address = await server.listen();
+    const address = await app.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
         name: 'test',
@@ -75,14 +76,15 @@ tap.test('plugin() - import map fetched from a URL', async (t) => {
     t.matchSnapshot(clean(code), 'import maps from urls');
 
     plugin.clear();
-    await server.close();
+    await app.close();
     await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
     t.end();
 });
 
 tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
-    const server = fastify();
-    server.get('/one', (request, reply) => {
+    const app = fastify();
+    app.server.keepAliveTimeout = 20;
+    app.get('/one', (request, reply) => {
         reply.send({
             imports: {
                 'lit-element': 'https://cdn.eik.dev/lit-element/v2',
@@ -91,7 +93,7 @@ tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
             },
         });
     });
-    const address = await server.listen();
+    const address = await app.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
         name: 'test',
@@ -118,28 +120,29 @@ tap.test('plugin() - import map fetched from a URL via eik.json', async (t) => {
     t.matchSnapshot(clean(code), 'eik.json import-map string');
 
     plugin.clear();
-    await server.close();
+    await app.close();
     await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
     t.end();
 });
 
 tap.test('plugin() - import maps via eik.json, URLs and direct definitions', async (t) => {
-    const server = fastify();
-    server.get('/one', (request, reply) => {
+    const app = fastify();
+    app.server.keepAliveTimeout = 20;
+    app.get('/one', (request, reply) => {
         reply.send({
             imports: {
                 'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             },
         });
     });
-    server.get('/two', (request, reply) => {
+    app.get('/two', (request, reply) => {
         reply.send({
             imports: {
                 'lit-html': 'https://cdn.eik.dev/lit-html/v1',
             },
         });
     });
-    const address = await server.listen();
+    const address = await app.listen();
 
     await fs.promises.writeFile(path.join(process.cwd(), 'eik.json'), JSON.stringify({
         name: 'test',
@@ -173,28 +176,29 @@ tap.test('plugin() - import maps via eik.json, URLs and direct definitions', asy
     t.matchSnapshot(clean(code), 'import maps from eik.json, urls and direct definition');
 
     plugin.clear();
-    await server.close();
+    await app.close();
     await fs.promises.unlink(path.join(process.cwd(), 'eik.json'));
     t.end();
 });
 
 tap.test('plugin() - import maps via package.json, URLs and direct definitions', async (t) => {
-    const server = fastify();
-    server.get('/one', (request, reply) => {
+    const app = fastify();
+    app.server.keepAliveTimeout = 20;
+    app.get('/one', (request, reply) => {
         reply.send({
             imports: {
                 'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             },
         });
     });
-    server.get('/two', (request, reply) => {
+    app.get('/two', (request, reply) => {
         reply.send({
             imports: {
                 'lit-html': 'https://cdn.eik.dev/lit-html/v1',
             },
         });
     });
-    const address = await server.listen();
+    const address = await app.listen();
 
     const packageJSON = JSON.parse(await fs.promises.readFile(path.join(process.cwd(), 'package.json'), 'utf-8'));
     packageJSON.eik = {
@@ -228,7 +232,7 @@ tap.test('plugin() - import maps via package.json, URLs and direct definitions',
     t.matchSnapshot(clean(code), 'import maps from eik.json, urls and direct definition');
 
     plugin.clear();
-    await server.close();
+    await app.close();
     delete packageJSON.eik;
     await fs.promises.writeFile(path.join(process.cwd(), 'package.json'), `${JSON.stringify(packageJSON, null, 2)}\n`);
     t.end();


### PR DESCRIPTION
This replaces `node-fetch` with `undici` and updates all dependencies. The replacement of `node-fetch` aligns this plugin with the other plugins.