### PR TITLE
fix: `maps` overrides should take priority

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,7 +68,7 @@ export async function load({
 	const config = await helpers.getDefaults(path);
 
 	const fetched = await fetchImportMaps([...config.map, ...pUrls]);
-	const mappings = pMaps.concat(fetched);
+	const mappings = fetched.concat(pMaps);
 
 	await importMapPlugin.load(mappings);
 }

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -5,6 +5,31 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/plugin.js > TAP > plugin() - direct definitions import should override fetched import maps > import maps from direct definition 1`] = `
+// fixtures/modules/file/main.js
+import { html } from "https://cdn.eik.dev/lit-html/v3";
+import { css } from "https://cdn.eik.dev/lit-html/v1";
+import { LitElement } from "https://cdn.eik.dev/lit-element/v2";
+var Inner = class extends LitElement {
+  static get styles() {
+    return [
+      css\`
+        :host {
+          color: red;
+        }
+      \`
+    ];
+  }
+  render(world) {
+    return html\`<p>Hello \${world}!</p>\`;
+  }
+};
+export {
+  Inner as default
+};
+
+`
+
 exports[`test/plugin.js > TAP > plugin() - import map fetched from a URL > import maps from urls 1`] = `
 // fixtures/modules/file/main.js
 import { html } from "https://cdn.eik.dev/lit-html/v2";


### PR DESCRIPTION
See https://github.com/eik-lib/esbuild-plugin/issues/196 for context

> If several of these options are used, maps takes precedence over urls which takes precedence over values loaded from an eik.json file.

No existing test was changed in this PR which shows that that this was not covered by tests before. 

This could be considered a breaking change since it changes the code to be aligned with the documentation which is a huge behavior change, I will leave that decision up to maintainers. 